### PR TITLE
add lesson image alt text based on title for acccessbility

### DIFF
--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -16,7 +16,7 @@
                                     <i class="fa fa-plus fa-3x"></i>
                                 </div>
                             </div>
-                            <img src="img/portfolio/{{ post.thumbnail }}" class="img-responsive img-centered" alt="">
+                            <img src="img/portfolio/{{ post.thumbnail }}" class="img-responsive img-centered" alt="{{ post.title }}">
                         </a>
                         <div class="portfolio-caption">
                             <h4>{{ post.title }}</h4>


### PR DESCRIPTION
the images in the "Lessons" section of the index are used as links, but have no alt text. Thus, screen reads or text-only browsers will have blank links with no clue of where they lead. I added the lesson title as the alt text, since the link leads to the lesson description modal. 