### PR TITLE
Changes for how Font Awesome organized branded logos (fab)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,11 +79,11 @@ people:
 
 # Social networks usernames (many more available: google-plus, flickr, dribbble, pinterest, instagram, tumblr, linkedin, etc.)
 social:
-  - title: twitter
+  - title: fab fa-twitter
     url: http://twitter.com/libcarpentry
-  - title: github
+  - title: fab fa-github
     url: https://github.com/LibraryCarpentry/
-  - title: gitter   
+  - title: fab fa-gitter   
     url: https://gitter.im/LibraryCarpentry/Lobby
 
 # Postal address (add as many lines as necessary)


### PR DESCRIPTION
@weaverbel When merged together with my other PR (forthcoming), this should add a Gitter logo to the footer.