### PR TITLE
fix OpenRefine modal thumbnail

### DIFF
--- a/_posts/2014-07-16-project-3.markdown
+++ b/_posts/2014-07-16-project-3.markdown
@@ -4,7 +4,7 @@ subtitle: An introduction to cleaning up and enhancing a dataset using OpenRefin
 layout: default
 modal-id: 3
 date: 2014-07-16
-img: open_ref.jpg
+img: open-ref.jpg
 thumbnail: open-ref.jpg
 alt: image-alt
 project-date: https://librarycarpentry.github.io/lc-open-refine/


### PR DESCRIPTION
`_posts/2014-07-16-project-3.markdown` had wrong file name for `img` variable, thus modal had no image. This adds the correct file name.